### PR TITLE
closes #3

### DIFF
--- a/Components/SentryClient.php
+++ b/Components/SentryClient.php
@@ -53,13 +53,19 @@ class SentryClient extends \Raven_Client
             } else {
                 // Probably backend user
                 try {
-                    $backendUser = Shopware()->Plugins()->Backend()->Auth()->checkAuth()->getIdentity();
-                    $this->user_context([
-                        'id' => $backendUser->id,
-                        'username' => $backendUser->username,
-                        'email' => $backendUser->email
-                    ]);
-                    $this->contextSet = true;
+                    $auth = Shopware()->Plugins()->Backend()->Auth()->checkAuth();
+
+                    if ($auth) {
+                        $backendUser = $auth->getIdentity();
+
+                        $this->user_context([
+                            'id' => $backendUser->id,
+                            'username' => $backendUser->username,
+                            'email' => $backendUser->email
+                        ]);
+                        $this->contextSet = true;
+
+                    }
                 } catch (\Exception $e) {
                 }
             }


### PR DESCRIPTION
This fixes #3. It seems there are certain situations in which there is no session initialized yet there is no backend session/authorization as well. In this case I get a getIdentity() on null in Components/SentryClient::captureException(). 