### PR TITLE
Make OdSentry ready for Shopware 5.6

### DIFF
--- a/OdSentry.php
+++ b/OdSentry.php
@@ -75,7 +75,7 @@ class OdSentry extends Plugin
         if (Shopware()->Config()->getByNamespace('OdSentry', 'sentryLogPhp')) {
             $privateDsn = Shopware()->Config()->getByNamespace('OdSentry', 'sentryPrivateDsn');
             $this->sentryClient = new SentryClient($privateDsn, [
-                'release' => \Shopware::VERSION,
+                'release' => $this->container->getParameter('shopware.release.version'),
                 'environment' => $this->container->getParameter('kernel.environment'),
                 'install_default_breadcrumb_handlers' => false
             ]);


### PR DESCRIPTION
Shopware::VERSION was deprecated in 5.4 and was removed in 5.6:
SW-20717 - Deprecate Shopware::Version constants, moving them to DIC (https://github.com/shopware/shopware/commit/91bedc0486429abcf996fd5ec2d08b6cf1e40e57)